### PR TITLE
Refresh upstreams

### DIFF
--- a/pkg/testutil/create_temp_file.go
+++ b/pkg/testutil/create_temp_file.go
@@ -1,0 +1,20 @@
+package testutil
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func CreateTempFile(t *testing.T, pattern string, content string) *os.File {
+	tempFile, err := ioutil.TempFile("", pattern)
+	if err != nil {
+		t.Fatalf("Error while creating temp file: %s", err)
+	}
+
+	if _, err := tempFile.Write([]byte(content)); err != nil {
+		t.Fatalf("Error while writing content to temp file: %s", err)
+	}
+
+	return tempFile
+}

--- a/pkg/upstream/initialize_test.go
+++ b/pkg/upstream/initialize_test.go
@@ -1,0 +1,50 @@
+package upstream
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/visola/go-proxy/pkg/testutil"
+)
+
+func TestRefreshStaleUpstreams(t *testing.T) {
+	// Ensure no upstreams
+	upstreams = make([]Upstream, 0)
+
+	fileName := "test.yml"
+	fileContent := `
+upstreams:
+  - name: backend
+`
+
+	tempFile := testutil.CreateTempFile(t, fileName, fileContent)
+	defer os.Remove(tempFile.Name())
+
+	origin := UpstreamOrigin{
+		File:     tempFile.Name(),
+		LoadedAt: 10,
+	}
+
+	AddUpstreams([]Upstream{
+		Upstream{
+			Name:   "test",
+			Origin: origin,
+		},
+	})
+
+	refreshStaleUpstreams()
+	assert.Equal(t, 2, len(upstreams))
+
+	// TODO - rewrite this to avoid accessing globals
+	first := upstreams[0]
+	assert.Equal(t, "test", first.Name)
+	assert.Equal(t, tempFile.Name(), first.Origin.File)
+
+	second := upstreams[1]
+	assert.Equal(t, "backend", second.Name)
+	assert.Equal(t, tempFile.Name(), second.Origin.File)
+
+	refreshStaleUpstreams()
+	assert.Equal(t, 2, len(upstreams))
+}

--- a/pkg/upstream/upstreams.go
+++ b/pkg/upstream/upstreams.go
@@ -19,9 +19,26 @@ var (
 	upstreamsMutex sync.Mutex
 )
 
+// AddUpstreams add an array of upstreams to the available array of upstreams
 func AddUpstreams(toAdd []Upstream) {
 	upstreamsMutex.Lock()
 	defer upstreamsMutex.Unlock()
 
 	upstreams = append(upstreams, toAdd...)
+}
+
+// UpstreamsPerFile returns a map with all upstreams grouped by file where they were loaded from
+func UpstreamsPerFile() map[string][]Upstream {
+	upstreamsPerFile := make(map[string][]Upstream)
+
+	for _, oldUpstream := range upstreams {
+		upstreamsInFile, exists := upstreamsPerFile[oldUpstream.Origin.File]
+		if !exists {
+			upstreamsInFile = make([]Upstream, 0)
+		}
+		upstreamsInFile = append(upstreamsInFile, oldUpstream)
+		upstreamsPerFile[oldUpstream.Origin.File] = upstreamsInFile
+	}
+
+	return upstreamsPerFile
 }

--- a/pkg/upstream/upstreams_test.go
+++ b/pkg/upstream/upstreams_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestUpstreamsPerFile(t *testing.T) {
+	// Ensure no upstreams
+	upstreams = make([]Upstream, 0)
+
 	firstOrigin := UpstreamOrigin{
 		File:     "/some/place/first",
 		LoadedAt: 10,

--- a/pkg/upstream/upstreams_test.go
+++ b/pkg/upstream/upstreams_test.go
@@ -1,0 +1,52 @@
+package upstream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpstreamsPerFile(t *testing.T) {
+	firstOrigin := UpstreamOrigin{
+		File:     "/some/place/first",
+		LoadedAt: 10,
+	}
+
+	AddUpstreams([]Upstream{
+		Upstream{
+			Name:   "Upstream 1",
+			Origin: firstOrigin,
+		},
+		Upstream{
+			Name:   "Upstream 2",
+			Origin: firstOrigin,
+		},
+	})
+
+	secondOrigin := UpstreamOrigin{
+		File:     "/another/file/second",
+		LoadedAt: 20,
+	}
+
+	AddUpstreams([]Upstream{
+		Upstream{
+			Name:   "Upstream 3",
+			Origin: secondOrigin,
+		},
+		Upstream{
+			Name:   "Upstream 4",
+			Origin: secondOrigin,
+		},
+		Upstream{
+			Name:   "Upstream 5",
+			Origin: secondOrigin,
+		},
+	})
+
+	groupedByFile := UpstreamsPerFile()
+
+	assert.Equal(t, 2, len(groupedByFile), "Should group by two origins")
+
+	assert.Equal(t, 2, len(groupedByFile[firstOrigin.File]))
+	assert.Equal(t, 3, len(groupedByFile[secondOrigin.File]))
+}


### PR DESCRIPTION
When initializing upstreams, add a go routine that checks for changes every few seconds. It will loop through all upstreams in memory, check if the loaded time for each is before the modified date of the file it was loaded from. If it is, reload the file. If not, preserve the old set of upstreams from that file.