### PR TITLE
Sort endpoints by specificity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876 // indirect
 	golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8 // indirect
-	golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4 // indirect
+	golang.org/x/tools v0.0.0-20191230220329-2aa90c603ae3 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.4
 )

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ golang.org/x/tools v0.0.0-20191004055002-72853e10c5a3 h1:2AmBLzhAfXj+2HCW09VCkJt
 golang.org/x/tools v0.0.0-20191004055002-72853e10c5a3/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4 h1:Toz2IK7k8rbltAXwNAxKcn9OzqyNfMUhUNjz3sL0NMk=
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20191230220329-2aa90c603ae3 h1:2+KluhQfJ1YhW+TB1KrISS2SfiG1pLEoseB0D4VF/bo=
+golang.org/x/tools v0.0.0-20191230220329-2aa90c603ae3/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/listener/handle_request.go
+++ b/pkg/listener/handle_request.go
@@ -2,6 +2,7 @@ package listener
 
 import (
 	"net/http"
+	"sort"
 
 	"github.com/visola/go-proxy/pkg/httputil"
 	"github.com/visola/go-proxy/pkg/upstream"
@@ -9,18 +10,24 @@ import (
 
 func handleRequest(listenerToHandle Listener, req *http.Request, resp http.ResponseWriter) {
 	handled := false
+
+	allEnabledEndpoints := make(upstream.Endpoints, 0)
 	for _, enabledUpstream := range listenerToHandle.EnabledUpstreams {
 		candidateUpstream, existsUpstream := upstream.Upstreams()[enabledUpstream]
 		if !existsUpstream {
 			// This is a weird state but it can happen if endpoints changed
 			continue
 		}
+		allEnabledEndpoints = append(allEnabledEndpoints, candidateUpstream.Endpoints()...)
+	}
 
-		for _, candidateEndpoint := range candidateUpstream.Endpoints() {
-			if candidateEndpoint.Matches(req) {
-				candidateEndpoint.Handle(req, resp)
-				handled = true
-			}
+	sort.Sort(allEnabledEndpoints)
+
+	for _, candidateEndpoint := range allEnabledEndpoints {
+		if candidateEndpoint.Matches(req) {
+			candidateEndpoint.Handle(req, resp)
+			handled = true
+			break
 		}
 	}
 

--- a/pkg/upstream/endpoint.go
+++ b/pkg/upstream/endpoint.go
@@ -20,6 +20,7 @@ type HandleResult struct {
 type Endpoint interface {
 	Handle(*http.Request, http.ResponseWriter) HandleResult
 	Matches(*http.Request) bool
+	Path() string
 }
 
 // BaseEndpoint represents a base endpoint route
@@ -42,6 +43,15 @@ func (m *BaseEndpoint) Matches(req *http.Request) bool {
 	}
 
 	return false
+}
+
+// Path returns the matching path for an endpoint
+func (m *BaseEndpoint) Path() string {
+	path := m.From
+	if path == "" {
+		path = m.Regexp
+	}
+	return path
 }
 
 func (m *BaseEndpoint) ensureRegexp() *regexp.Regexp {

--- a/pkg/upstream/endpoints.go
+++ b/pkg/upstream/endpoints.go
@@ -26,5 +26,11 @@ func (a Endpoints) Less(i, j int) bool {
 		return len(pathParts1) > len(pathParts2)
 	}
 
-	return path1 > path2
+	for i, pathPart1 := range pathParts1 {
+		if len(pathPart1) != len(pathParts2[i]) {
+			return len(pathPart1) > len(pathParts2[i])
+		}
+	}
+
+	return path1 < path2
 }

--- a/pkg/upstream/endpoints.go
+++ b/pkg/upstream/endpoints.go
@@ -1,0 +1,30 @@
+package upstream
+
+import "strings"
+
+// Endpoints represents a sortable array of endpoints
+type Endpoints []Endpoint
+
+func (a Endpoints) Len() int {
+	return len(a)
+}
+
+func (a Endpoints) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a Endpoints) Less(i, j int) bool {
+	e1 := a[i]
+	e2 := a[j]
+
+	path1 := e1.Path()
+	path2 := e2.Path()
+	pathParts1 := strings.Split(path1, "/")
+	pathParts2 := strings.Split(path2, "/")
+
+	if len(pathParts1) != len(pathParts2) {
+		return len(pathParts1) > len(pathParts2)
+	}
+
+	return path1 > path2
+}

--- a/pkg/upstream/endpoints_test.go
+++ b/pkg/upstream/endpoints_test.go
@@ -1,0 +1,42 @@
+package upstream
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEndpointsSorting(t *testing.T) {
+	e1 := &StaticEndpoint{
+		BaseEndpoint: BaseEndpoint{
+			From: "/first/second/third",
+		},
+	}
+
+	e2 := &StaticEndpoint{
+		BaseEndpoint: BaseEndpoint{
+			Regexp: "/first/(.+)/forth",
+		},
+	}
+
+	e3 := &StaticEndpoint{
+		BaseEndpoint: BaseEndpoint{
+			From: "/",
+		},
+	}
+
+	e4 := &StaticEndpoint{
+		BaseEndpoint: BaseEndpoint{
+			Regexp: "/another/(.+)",
+		},
+	}
+
+	arr := Endpoints{e2, e3, e1, e4}
+	sort.Sort(arr)
+
+	assert.Equal(t, e1, arr[0])
+	assert.Equal(t, e2, arr[1])
+	assert.Equal(t, e4, arr[2])
+	assert.Equal(t, e3, arr[3])
+}

--- a/pkg/upstream/endpoints_test.go
+++ b/pkg/upstream/endpoints_test.go
@@ -1,6 +1,7 @@
 package upstream
 
 import (
+	"math/rand"
 	"sort"
 	"testing"
 
@@ -8,35 +9,38 @@ import (
 )
 
 func TestEndpointsSorting(t *testing.T) {
-	e1 := &StaticEndpoint{
-		BaseEndpoint: BaseEndpoint{
-			From: "/first/second/third",
-		},
+	expectedPaths := []string{
+		"/another/(.+)/forth",
+		"/first/second/on",
+		"/first/(.+)/on",
+		"/another/second",
+		"/another/(.+)",
+		"/single",
+		"/(.+)",
+		"/",
 	}
 
-	e2 := &StaticEndpoint{
-		BaseEndpoint: BaseEndpoint{
-			Regexp: "/first/(.+)/forth",
-		},
+	arr := make(Endpoints, len(expectedPaths))
+	for i, p := range expectedPaths {
+		if i%2 == 0 {
+			arr[i] = &StaticEndpoint{
+				BaseEndpoint: BaseEndpoint{From: p},
+			}
+		} else {
+			arr[i] = &StaticEndpoint{
+				BaseEndpoint: BaseEndpoint{Regexp: p},
+			}
+		}
 	}
 
-	e3 := &StaticEndpoint{
-		BaseEndpoint: BaseEndpoint{
-			From: "/",
-		},
-	}
+	rand.Seed(10)
+	rand.Shuffle(len(arr), func(i, j int) {
+		arr[i], arr[j] = arr[j], arr[i]
+	})
 
-	e4 := &StaticEndpoint{
-		BaseEndpoint: BaseEndpoint{
-			Regexp: "/another/(.+)",
-		},
-	}
-
-	arr := Endpoints{e2, e3, e1, e4}
 	sort.Sort(arr)
 
-	assert.Equal(t, e1, arr[0])
-	assert.Equal(t, e2, arr[1])
-	assert.Equal(t, e4, arr[2])
-	assert.Equal(t, e3, arr[3])
+	for i := 0; i < len(expectedPaths); i++ {
+		assert.Equal(t, expectedPaths[i], arr[i].Path())
+	}
 }

--- a/web/src/js/components/Upstreams.svelte
+++ b/web/src/js/components/Upstreams.svelte
@@ -34,6 +34,23 @@ function updateEndpoints() {
     u.proxyEndpoints.forEach(addToEndpoints);
     u.staticEndpoints.forEach(addToEndpoints);
   });
+
+  endpoints.sort((e1, e2) => {
+    const path1 = e1.from == "" ? e1.regexp : e1.from;
+    const path2 = e2.from == "" ? e2.regexp : e2.from;
+
+    const partCountDiff = path2.split("/").length - path1.split("/").length;
+    if (partCountDiff != 0) {
+      return partCountDiff;
+    }
+
+    const pathLengthDiff = path2.length - path1.length;
+    if (pathLengthDiff != 0) {
+      return pathLengthDiff;
+    }
+
+    return path1.localeCompare(path2);
+  });
 }
 
 function upstreamSelected(checked, name) {


### PR DESCRIPTION
### User Story

As a user I want my endpoints to match by specificity.

### Descritpion

To define specificity, first we need to define a few things:

- *field* - is what will be used to check for specificity. The field that is not empty will be used: `from` or `regexp`.
- *part* - the field is considered a path. A path is composed of parts which are separated by `/`. Splitting the field by `/` should return an array of parts.

With the previous definitions in place, specificity is defined by sorting the array of all available endpoints by the following criteria:

1. The ones with most number of path parts first
1. After this doesn't actually matter, but for stability, they will be then sorted alphabetically by each path.

### Acceptance Criteria

- [x] Sort endpoints by specificity before matching
- [x] Show endpoints sorted by specificity on the Admin UI