### PR TITLE
Reuse http.Client to avoid issue with DNS lookup

### DIFF
--- a/pkg/httputil/internal_error.go
+++ b/pkg/httputil/internal_error.go
@@ -2,13 +2,14 @@ package httputil
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 )
 
 // InternalError sends an HTTP 500 with a text/plain message showing the error message
 // It also logs the message.
 func InternalError(req *http.Request, w http.ResponseWriter, err error) {
-	fmt.Printf("Error: %s\n", err)
+	log.Printf("Error: %s\n", err)
 	w.WriteHeader(http.StatusInternalServerError)
 	w.Write([]byte(fmt.Sprintf("Sorry, something went wrong: '%s'\n", err)))
 }

--- a/pkg/listener/handle_request.go
+++ b/pkg/listener/handle_request.go
@@ -42,9 +42,9 @@ func handleRequest(listenerToHandle Listener, req *http.Request, resp http.Respo
 	result := newHandleResult(req)
 	RequestHandlingChanged(result)
 
-	defer req.Body.Close()
 	var readErr error
 	result.Request.Body, readErr = ioutil.ReadAll(req.Body)
+	req.Body.Close()
 	if readErr != nil {
 		httputil.InternalError(req, resp, readErr)
 		result.StatusCode = http.StatusNotFound


### PR DESCRIPTION
During high volume of requests scenario, I've noticed that creating a new HTTP Client for each request was causing the following error:

```
dial tcp: lookup localhost: no such host
```

Reusing the http.Client seems to fix this issue.